### PR TITLE
ONE-000: adding composer update and rebase scripts for upstreams.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,6 +145,12 @@
             "blt internal:create-project:init-repo"
         ],
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+        "acms-update": [
+            "./scripts/acms-update.sh"
+        ],
+        "acms-rebase": [
+            "./scripts/acms-rebase.sh"
+        ],
         "nuke": [
             "rm -rf vendor composer.lock docroot/core docroot/modules/contrib docroot/profiles/contrib docroot/themes/contrib",
             "@composer clearcache --ansi",

--- a/scripts/acms-rebase.sh
+++ b/scripts/acms-rebase.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+#-------------------------- Helper functions -----------------------------
+
+# Console colors
+red='\033[0;31m'
+green='\033[0;32m'
+green_bg='\033[42m'
+yellow='\033[1;33m'
+NC='\033[0m'
+
+echo-red () { echo -e "${red}$1${NC}"; }
+echo-green () { echo -e "${green}$1${NC}"; }
+echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
+echo-yellow () { echo -e "${yellow}$1${NC}"; }
+
+#-------------------------- END: Helper functions ------------------------
+
+echo -e "${green}Fetching ACMS repository updates...${NC}"
+cd upstreams/acquia_cms
+git fetch origin
+
+if [ -z "$(git status --porcelain)" ]; then
+  echo -e "${green}Rebasing against origin/develop...${NC}"
+  git rebase origin/develop
+
+  else
+  echo -e "${red}Warning: uncommitted changes detected. Please commit ACMS changes before rebasing.${NC}"
+fi

--- a/scripts/acms-update.sh
+++ b/scripts/acms-update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#-------------------------- Helper functions -----------------------------
+
+# Console colors
+red='\033[0;31m'
+green='\033[0;32m'
+green_bg='\033[42m'
+yellow='\033[1;33m'
+NC='\033[0m'
+
+echo-red () { echo -e "${red}$1${NC}"; }
+echo-green () { echo -e "${green}$1${NC}"; }
+echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
+echo-yellow () { echo -e "${yellow}$1${NC}"; }
+
+#-------------------------- END: Helper functions ------------------------
+
+echo -e "${green}Fetching ACMS repository updates...${NC}"
+cd upstreams/acquia_cms
+git fetch origin
+
+if [ -z "$(git status --porcelain)" ]; then
+  echo -e "${green}Resetting local ACMS state...${NC}"
+  git checkout develop
+
+  echo -e "${green}Running composer update...${NC}"
+  cd ../../
+  composer update acquia/acquia_cms --with-all-dependencies
+
+  else
+  echo -e "${red}Warning: uncommitted changes detected. Please commit ACMS changes before updating.${NC}"
+fi


### PR DESCRIPTION
Issue:
Running `composer update acquia/acquia_cms` from the project won't actually update the profile without first doing a git fetch. 

Proposed solution:
Custom composer scripts to update and rebase the upstream repository.