### PR TITLE
PF-3812: Update gitignore to specify local files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,11 @@
 # @see https://git.drupalcode.org/project/drupal/-/blob/9.2.x/example.gitignore
 /docroot/core
 /vendor/
-/docroot/sites/*/settings*.php
 /docroot/sites/*/services*.yml
 /docroot/sites/*/files
 /docroot/sites/*/private
 /docroot/sites/simpletest
+/docroot/sites/*/local.*
 
 # Files created by ACMS
 /docroot/.gitignore


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes PF-3812

**Proposed changes**
Updates .gitignore so the site settings.php files are no longer ignored by git. Instead, only files containing "local" under the site's directory are ignored.

**Alternatives considered**
The alternative solutions are:
1. Users remove/update this line in this project prior to actually using it.
2. Users leave the settings.php file ignored & manually add/edit settings.php directly on Acquia Cloud servers.
It is standard practice to git commit the settings.php file, hence this PR has been opened.

**Testing steps**
1. Create a new project using `composer create-project acquia/acquia-cms-project`
2. Install a Drupal site locally using any method you would traditionally use (e.g. `blt setup`)
3. Do `git status` and note that the docroot/sites/default/settings.php is not currently staged to be git committed
4. Once this PR is merged, you should see the settings.php file staged for commit

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
